### PR TITLE
Update Cargo.toml license setting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "markdown-gen"
 version = "1.2.1"
-license = "MIT"
 license-file = "LICENSE"
 description = "Crate for generating Markdown files"
 categories = ["encoding", "text-processing"]


### PR DESCRIPTION
Cargo  complains that only 1 of `license` or `license-file` are necessary.

Signed-off-by: Hanif Bin Ariffin <hanif.ariffin.4326@gmail.com>